### PR TITLE
Manifests-Required lists the types

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The following fields make up a BagIt profile. Each field is a top-level JSON key
 
 3. `Manifests-Required`: LIST
 
-	Each manifest file in LIST is required. The list contains the type of manifest, not
+	Each manifest type in LIST is required. The list contains the type of manifest, not
 	the complete filename, e.g. `["sha1", "md5"]`.
 	
 4. `Allow-Fetch.txt`: `true`|`false`

--- a/README.md
+++ b/README.md
@@ -62,8 +62,9 @@ The following fields make up a BagIt profile. Each field is a top-level JSON key
 
 3. `Manifests-Required`: LIST
 
-	Each manifest file in LIST is required.
-
+	Each manifest file in LIST is required. The list contains the type of manifest, not
+	the complete filename, e.g. `["sha1", "md5"]`.
+	
 4. `Allow-Fetch.txt`: `true`|`false`
 
 	A fetch.txt file is allowed within the bag. Default: `true`


### PR DESCRIPTION
not filenames! At least if the examples are true..