### PR TITLE
Clarify BagIt-Profile-Identifier usage in bags

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ BagIt Profiles Specification
 
 Status of this specification
 ---
-Current version: 1.0 (2013-05-19). Maintained by Mark Jordan and Nick Ruest. 
+Current version: 1.0.1 (2015-08-06). Maintained by Mark Jordan and Nick Ruest. 
 
 Original draft created by members of the Access 2012 Hackfest group: Meghan Currie, Krista Godfrey, Mark Jordan, Nick Ruest, William Wueppelmann, and Dan Chudnov. 
 
@@ -16,7 +16,7 @@ Please comment on this draft specification in the Digital Curation Google Group,
 Purpose and background
 ---
 
-The purpose of the BagIt Profiles Specification is to allow creators and consumers of Bags to agree on optional components of the Bags they are exchanging. Details of the profile are instantiated in a JSON file that both the producing and consuming applications interpret using the conventions described below. The profile file sits at an HTTP URI (e.g., http://foo.example.com/bagitprofiles/profile-bar.json), and can therefore be read by any number of applications creating or consuming Bags:
+The purpose of the BagIt Profiles Specification is to allow creators and consumers of Bags to agree on optional components of the Bags they are exchanging. Details of the profile are instantiated in a JSON file that both the producing and consuming applications interpret using the conventions described below. The profile file sits at an HTTP URI (e.g., `http://example.com/bagitprofiles/profile-bar-v0.1.json`), and can therefore be read by any number of applications creating or consuming Bags:
 
 	                        BagIt Profile JSON file
                                         /       \
@@ -34,9 +34,9 @@ Workflow
 
 The intended workflow for using a BagIt profile is: 
 
-1. The creator of the Bags ensures that Bags it produces meet all of the constraints expressed in the agreed-upon profile file.
+1. The creator of the Bags ensures that Bags it produces meet all of the constraints expressed in the agreed-upon and published BagIt profile file. The creator declares the `BagIt-Profile-Identifier` in the `bag-info.txt` file of the Bags.
 
-2. The consumer of the Bags retrieves the profile file from its URI and validates incoming Bags against it; specifically, it must complete the Bag if fetch.txt is present, validate the complete Bag against the profile, and then validate the Bag against the cannonical BagIt spec. 
+2. The consumer of the Bags identifies the profile(s) from the `BagIt-Profile-Identifier` field in their `bag-info.txt`. The consumer then retrieves the profile file from its URI and validates incoming Bags against it; specifically, it must complete the Bag if `fetch.txt` is present, validate the complete Bag against the profile, and then validate the Bag against the cannonical BagIt spec. 
 
 Each of these steps may be performed by a separate tool or microservice; in fact, implementers may integrate validation functionality in tools that perform other Bag-processing functions. For example, the completion of a holey Bag might be performed by a more general Bag-processing tool and need not be delegated to a separate validation tool. 
 
@@ -44,6 +44,12 @@ Some profile constraints are fatal: for example, failure to validate 'Accept-Ser
 
 Implementation details
 ---
+
+Bags complying to a BagIt profile MUST contain the tag `BagIt-Profile-Identifier`
+in their `bag-info.txt`, which value is the URI of the JSON file containing the profile it 
+conform to.  This tag MAY be repeated if the bag conforms to multiple profiles.
+The URI that identifies the profile SHOULD be versioned, e.g. `http://example.com/bagitprofiles/profile-bar-v0.1.json`. 
+Resolving the URI with `Accept: application/json` SHOULD provide a BagIt Profile as JSON according to this specification.
 
 The following fields make up a BagIt profile. Each field is a top-level JSON key, as illustrated in the examples that follow. LIST in the field definitions indicates that the key can have one or more values, serialized as a JSON array. Itemized values separated by a | indicate allowed options for that field.
 
@@ -53,11 +59,10 @@ The following fields make up a BagIt profile. Each field is a top-level JSON key
 
 2. `Bag-Info`:
 
-	Specifies which tags are required, etc. in bag-info.txt. Each tag definition takes two optional parameters: 1) "required" is true or false (default false) and indicates whether or not this tag is required. 2) "values" is a list of acceptable values. If empty, any value is accepted.
+	Specifies which tags are required, etc. in `bag-info.txt`. Each tag definition takes two optional parameters: 1) "required" is true or false (default false) and indicates whether or not this tag is required. 2) "values" is a list of acceptable values. If empty, any value is accepted.
 	
 	Implementers may define in the Bag-Info section of their profile whatever tags their application requires, i.e., tags defined here are not limited to the 'reserved metadata element names' identified in the BagIt spec.
-
-	bag-info.txt must contain the tag 'BagIt-Profile-Identifier', with a value of the URI of the JSON file containing the profile. Since Bags complying to a profile must contain this tag, they must also contain a bag-info.txt file.
+	The tag `BagIt-Profile-Identifier` is always required, but SHOULD NOT be listed under `Bag-Info` in the profile.
 
 
 3. `Manifests-Required`: LIST
@@ -87,7 +92,7 @@ The following fields make up a BagIt profile. Each field is a top-level JSON key
 
 9. `Tag-Files-Required`: LIST
 
-  A list of a tag files that must be included in a conformant Bag. Entries are full path names relative to the Bag base directory. As per the [BagIt Spec](http://tools.ietf.org/html/draft-kunze-bagit-08), these tag files need not be listed in tag manifiest files.
+  A list of a tag files that must be included in a conformant Bag. Entries are full path names relative to the Bag base directory. As per the [BagIt Spec](http://tools.ietf.org/html/draft-kunze-bagit-08), these tag files need not be listed in tag manifiest files. `Tag-Files-Required` SHOULD NOT include `bag-info.txt` (which is always required), nor any required manifest files, which instead are required by `Manifests-Required` and `Tag-Manifests-Required`.
 
 Examples
 ---


### PR DESCRIPTION
Fixes issue #4.

I moved up the `BagIt-Profile-Identifier` from not just being inside `Bag-Info` - and left a mark that it SHOULD NOT be implicitly listed.